### PR TITLE
Fix connections not closing. Clean up environment variables.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  db:
+    image: mongo
+    network_mode: host
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,3 @@ services:
   db:
     image: mongo
     network_mode: host
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: test

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node server/server.js",
-    "test": "export NODE_ENV=test || SET \"NODE_ENV=test\" && mocha server/**/*.test.js",
+    "start": "./server/bin/server",
+    "test": "NODE_ENV=test JWT_SECRET='this is a secret ssssh' mocha server/**/*.test.js",
     "test-watch": "nodemon --exec \"npm test\" "
   },
   "engines": {

--- a/server/bin/server
+++ b/server/bin/server
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+const PORT = process.env.PORT || 8001;
+
+require('../server').app.listen(PORT, () => {
+    console.log(`App listening on ${PORT}`);
+});

--- a/server/db/mongoose.js
+++ b/server/db/mongoose.js
@@ -1,10 +1,11 @@
 var mongoose = require('mongoose');
 var {ObjectID} = require('mongodb');
-var url = process.env.MONGODB_URI || 'mongodb://root:test@localhost:27017';
+
+var url = process.env.MONGODB_URI || 'mongodb://localhost:27017/TodoAppTest';
 
 // Telling mongoose which Promise lib to use
 mongoose.Promise = global.Promise;
-mongoose.connect(url, {});
+mongoose.connect(url, { useNewUrlParser: true });
 
 module.exports = {
     mongoose,

--- a/server/db/mongoose.js
+++ b/server/db/mongoose.js
@@ -1,9 +1,10 @@
 var mongoose = require('mongoose');
 var {ObjectID} = require('mongodb');
-var url = process.env.MONGODB_URI;
+var url = process.env.MONGODB_URI || 'mongodb://root:test@localhost:27017';
+
 // Telling mongoose which Promise lib to use
 mongoose.Promise = global.Promise;
-mongoose.connect(url, {useNewUrlParser: true});
+mongoose.connect(url, {});
 
 module.exports = {
     mongoose,

--- a/server/server.js
+++ b/server/server.js
@@ -5,7 +5,6 @@ const bodyParser = require('body-parser');
 const _ = require('lodash');
 
 const {ObjectID} = require('./db/mongoose');
-const PORT = process.env.PORT;
 
 const {User} = require('./models/user_model');
 const {Todo} = require('./models/todo_model');
@@ -153,9 +152,5 @@ var idValidator = (id) => {
 
     return {id, isValid};
 };
-
-app.listen(PORT, () => {
-    console.log(`App listening on ${PORT}`);
-});
 
 module.exports = {app};

--- a/server/tests/sever.test.js
+++ b/server/tests/sever.test.js
@@ -11,6 +11,10 @@ const {todos, users, populateTodos, populateUsers} = require('./seed/seed');
 beforeEach(populateUsers);
 beforeEach(populateTodos);
 
+after(function() {
+	return require('../db/mongoose').mongoose.disconnect();
+});
+
 describe('POST /todos', () => {
     it('should create a todo', (done) => {
         var text = 'Test Todos';


### PR DESCRIPTION
There were issues with mongoose not closing connections when the tests
ran as well as the http server itself not shutting down properly. The
mongoose driver now disconnects at the end of the tests. Supertest
already handles shutting down the app for you, just had to factor out
the `app.listen` into a different file.